### PR TITLE
Fix SGP4 crate compilation if clang is not used

### DIFF
--- a/sgp4/build.rs
+++ b/sgp4/build.rs
@@ -16,7 +16,7 @@ fn main() {
     // Use the `cc` crate to build a C file and statically link it.
     cc::Build::new()
         .file("src/c/sgp4.c")
-        .flag("-Wno-dangling-else")
+        .flag_if_supported("-Wno-dangling-else")
         .compile("libsgp4.a");
 
     let bindings = bindgen::Builder::default()


### PR DESCRIPTION
-Wno-dangling-else flag should only be included on compilers that supports it (for instance, cl.exe from MSVC does not recognize this flag).